### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/amrhassan/graphique-client-python.svg?branch=master)](https://travis-ci.org/amrhassan/graphique-client-python) [![Latest Version](https://pypip.in/version/graphique-client/badge.svg?style=flat)](https://pypi.python.org/pypi/graphique-client/) [![Supported Python versions](https://pypip.in/py_versions/graphique-client/badge.svg?style=flat)](https://pypi.python.org/pypi/graphique-client/)
+[![Build Status](https://travis-ci.org/amrhassan/graphique-client-python.svg?branch=master)](https://travis-ci.org/amrhassan/graphique-client-python) [![Latest Version](https://img.shields.io/pypi/v/graphique-client.svg?style=flat)](https://pypi.python.org/pypi/graphique-client/) [![Supported Python versions](https://img.shields.io/pypi/pyversions/graphique-client.svg?style=flat)](https://pypi.python.org/pypi/graphique-client/)
 
 Python Client for [Graphique](https://amrhassan.github.io/graphique)
 ===========================


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20graphique-client))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `graphique-client`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.